### PR TITLE
Add a linear term to rehline.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,16 @@ eigen3.zip
 # Package sdist
 *.tar.gz
 *.whl
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "esbonio.sphinx.confDir": ""
+    "esbonio.sphinx.confDir": "",
+    "files.associations": {
+        "random": "cpp"
+    }
 }

--- a/rehline/_class.py
+++ b/rehline/_class.py
@@ -14,10 +14,10 @@ from ._internal import rehline_internal, rehline_result
 def ReHLine_solver(X, U, V,
         Tau=np.empty(shape=(0, 0)),
         S=np.empty(shape=(0, 0)), T=np.empty(shape=(0, 0)),
-        A=np.empty(shape=(0, 0)), b=np.empty(shape=(0)),
+        A=np.empty(shape=(0, 0)), b=np.empty(shape=(0)), mu=np.empty(shape=(0)),
         max_iter=1000, tol=1e-4, shrink=1, verbose=1, trace_freq=100):
     result = rehline_result()
-    rehline_internal(result, X, A, b, U, V, S, T, Tau, max_iter, tol, shrink, verbose, trace_freq)
+    rehline_internal(result, X, A, b, U, V, S, T, Tau, mu, max_iter, tol, shrink, verbose, trace_freq)
     return result
 
 class ReHLine(BaseEstimator):
@@ -25,7 +25,7 @@ class ReHLine(BaseEstimator):
 
     .. math::
 
-        \min_{\mathbf{\beta} \in \mathbb{R}^d} \sum_{i=1}^n \sum_{l=1}^L \text{ReLU}( u_{li} \mathbf{x}_i^\intercal \mathbf{\beta} + v_{li}) + \sum_{i=1}^n \sum_{h=1}^H {\text{ReHU}}_{\tau_{hi}}( s_{hi} \mathbf{x}_i^\intercal \mathbf{\beta} + t_{hi}) + \frac{1}{2} \| \mathbf{\beta} \|_2^2, \\ \text{ s.t. } 
+        \min_{\mathbf{\beta} \in \mathbb{R}^d} \sum_{i=1}^n \sum_{l=1}^L \text{ReLU}( u_{li} \mathbf{x}_i^\intercal \mathbf{\beta} + v_{li}) + \sum_{i=1}^n \sum_{h=1}^H {\text{ReHU}}_{\tau_{hi}}( s_{hi} \mathbf{x}_i^\intercal \mathbf{\beta} + t_{hi}) + \frac{1}{2} \| \mathbf{\beta} \|_2^2 - \mathbf{beta}^T \mathbf{\mu}, \\ \text{ s.t. } 
         \mathbf{A} \mathbf{\beta} + \mathbf{b} \geq \mathbf{0},
         
     where :math:`\mathbf{U} = (u_{li}),\mathbf{V} = (v_{li}) \in \mathbb{R}^{L \times n}` 
@@ -59,6 +59,9 @@ class ReHLine(BaseEstimator):
 
     b: array of shape (K, ), default=np.empty(shape=0)
         The intercept vector in the linear constraint.
+
+    mu: array of shape (d, ), default=np.empty(shape=0)
+        The additional linear term
     
 
     Attributes
@@ -117,7 +120,7 @@ class ReHLine(BaseEstimator):
                        U=np.empty(shape=(0,0)), V=np.empty(shape=(0,0)),
                        Tau=np.empty(shape=(0,0)),
                        S=np.empty(shape=(0,0)), T=np.empty(shape=(0,0)),
-                       A=np.empty(shape=(0,0)), b=np.empty(shape=(0)),
+                       A=np.empty(shape=(0,0)), b=np.empty(shape=(0)), mu=np.empty(shape=(0)),
                        max_iter=1000, tol=1e-4, shrink=1, verbose=0, trace_freq=100):
         self.loss = loss
         self.C = C
@@ -128,6 +131,7 @@ class ReHLine(BaseEstimator):
         self.Tau = Tau
         self.A = A
         self.b = b
+        self.mu = mu
         self.max_iter = max_iter
         self.tol = tol
         self.shrink = shrink
@@ -138,7 +142,7 @@ class ReHLine(BaseEstimator):
         self.H = S.shape[0]
         self.K = A.shape[0]
 
-    def make_ReLHLoss(self, X, y, loss={}):
+    def make_ReLHLoss(self, X, y=None, loss={}):
         """The `make_ReLHLoss` function generates parameters for the ReLoss, based on the provided training data.
 
         The function matches the specific ReLoss (self.loss) with loss functions 
@@ -216,11 +220,15 @@ class ReHLine(BaseEstimator):
             self.Tau = np.sqrt(self.C) * loss['tau'] * np.ones((2, n))
 
             self.S[0] = - np.sqrt(self.C)
-            self.S[1] =   np.sqrt(self.C)
+            self.S[1] = np.sqrt(self.C)
             self.T[0] = np.sqrt(self.C)*y
             self.T[1] = -np.sqrt(self.C)*y
         elif (self.loss['name'] == 'custom'):
-            pass
+            self.U = self.loss['func'].relu_coef*self.C
+            self.V = self.loss['func'].relu_intercept*self.C
+            self.S = self.loss['func'].rehu_coef*np.sqrt(self.C)
+            self.T = self.loss['func'].rehu_intercept*np.sqrt(self.C)
+            self.Tau = self.loss['func'].rehu_cut*np.sqrt(self.C)
         else:
             raise Exception("Sorry, ReHLine currently does not support this loss function, \
                             but you can manually set ReLoss params to solve the problem.")
@@ -232,7 +240,7 @@ class ReHLine(BaseEstimator):
 
         .. math::
 
-            \min_{\mathbf{\beta} \in \mathbb{R}^d} \sum_{i=1}^n \sum_{l=1}^L \text{ReLU}( u_{li} \mathbf{x}_i^\intercal \mathbf{\beta} + v_{li}) + \sum_{i=1}^n \sum_{h=1}^H {\text{ReHU}}_{\tau_{hi}}( s_{hi} \mathbf{x}_i^\intercal \mathbf{\beta} + t_{hi}) + \frac{1}{2} \| \mathbf{\beta} \|_2^2 + \lambda_1 \| \mathbf{\beta} \|_1, \\ \text{ s.t. } 
+            \min_{\mathbf{\beta} \in \mathbb{R}^d} \sum_{i=1}^n \sum_{l=1}^L \text{ReLU}( u_{li} \mathbf{x}_i^\intercal \mathbf{\beta} + v_{li}) + \sum_{i=1}^n \sum_{h=1}^H {\text{ReHU}}_{\tau_{hi}}( s_{hi} \mathbf{x}_i^\intercal \mathbf{\beta} + t_{hi}) + \frac{1}{2} \| \mathbf{\beta} \|_2^2 - \mathbf{beta}^T \mathbf{\mu} + \lambda_1 \| \mathbf{\beta} \|_1, \\ \text{ s.t. } 
             \mathbf{A} \mathbf{\beta} + \mathbf{b} \geq \mathbf{0},
 
         where :math:`\lambda_1` is associated with `l1_pen`.
@@ -322,6 +330,7 @@ class ReHLine(BaseEstimator):
         self.H = self.S.shape[0]
         self.K = self.A.shape[0]
 
+    # this code block could be wrong
     def call_ReLHLoss(self, score):
         """
         Return the value of the ReHLine loss of the `score`.
@@ -337,13 +346,15 @@ class ReHLine(BaseEstimator):
             ReHLine loss evaluation of the given score.
         """
 
-        relu_input = np.zeros((self.L, self.n))
-        rehu_input = np.zeros((self.H, self.n))
-        if self.L > 0:
-            relu_input = (self.U.T * score[:,np.newaxis]).T + self.V
-        if self.H > 0:
+        ans = 0
+        if len(self.U) > 0:
+            relu_input = (self.U.T * score[:,np.newaxis]).T + self.V 
+            ans += np.sum(relu(relu_input), 0).sum()
+        if len(self.S) > 0:
             rehu_input = (self.S.T * score[:,np.newaxis]).T + self.T
-        return np.sum(relu(relu_input), 0) + np.sum(rehu(rehu_input), 0)
+            ans += np.sum(rehu(rehu_input, cut=self.Tau), 0).sum()
+        return ans
+
 
 
     def fit(self, X, sample_weight=None):
@@ -391,7 +402,7 @@ class ReHLine(BaseEstimator):
                                 U=U_weight, V=V_weight,
                                 Tau=Tau_weight,
                                 S=S_weight, T=T_weight,
-                                A=self.A, b=self.b,
+                                A=self.A, b=self.b, mu=self.mu,
                                 max_iter=self.max_iter, tol=self.tol,
                                 shrink=self.shrink, verbose=self.verbose,
                                 trace_freq=self.trace_freq)

--- a/rehline/_loss.py
+++ b/rehline/_loss.py
@@ -7,7 +7,7 @@
 
 
 import numpy as np
-from ._base import relu, rehu, _check_relu
+from ._base import relu, rehu, _check_relu, _check_rehu
 
 class ReHLoss(object):
     """
@@ -72,7 +72,13 @@ class ReHLoss(object):
         _check_rehu(self.rehu_coef, self.rehu_intercept, self.rehu_cut)
 
         self.L, self.H, self.n = self.relu_coef.shape[0], self.rehu_coef.shape[0], self.relu_coef.shape[1]
-        relu_input = (self.relu_coef.T * x[:,np.newaxis]).T + self.relu_intercept
-        rehu_input = (self.rehu_coef.T * x[:,np.newaxis]).T + self.rehu_intercept
 
-        return np.sum(relu(relu_input), 0) + np.sum(rehu(rehu_input), 0)
+        ans = 0
+        if len(self.relu_coef) > 0:
+            relu_input = (self.relu_coef.T * x[:,np.newaxis]).T + self.relu_intercept 
+            ans += np.sum(relu(relu_input), 0).sum()
+        if len(self.rehu_coef) > 0:
+            rehu_input = (self.rehu_coef.T * x[:,np.newaxis]).T + self.rehu_intercept
+            ans += np.sum(rehu(rehu_input, cut=self.rehu_cut), 0).sum()
+
+        return ans

--- a/src/rehline.cpp
+++ b/src/rehline.cpp
@@ -22,11 +22,12 @@ void rehline_internal(
     const MapMat& X, const MapMat& A, const MapVec& b,
     const MapMat& U, const MapMat& V,
     const MapMat& S, const MapMat& T, const MapMat& Tau,
+    const MapVec& mu,
     int max_iter, double tol, int shrink = 1,
     int verbose = 0, int trace_freq = 100
 )
 {
-    rehline::rehline_solver(result, X, A, b, U, V, S, T, Tau,
+    rehline::rehline_solver(result, X, A, b, U, V, S, T, Tau, mu,
                             max_iter, tol, shrink, verbose, trace_freq);
 }
 

--- a/tests/_test_po.py
+++ b/tests/_test_po.py
@@ -1,0 +1,63 @@
+import os
+
+import pandas as pd
+import numpy as np
+from numpy import linalg as LA
+
+from pypfopt import expected_returns, risk_models
+from pypfopt import EfficientFrontier, objective_functions
+
+from rehline import ReHLine
+
+
+def resource(name):
+    return os.path.join(os.path.dirname(__file__), "resources", name)
+
+
+def get_data():
+    return pd.read_csv(resource("stock_prices.csv"), parse_dates=True, index_col="date")
+
+"""
+\min_{w \in \R^n} -mu' w + alpha/2 * w' S w + \sum_i phi_i(w_i) s.t. w'1 = 1 & w >= 0
+where phi_i(w) = transaction_cost * |w - w^pre_i|
+"""
+
+prices = get_data()
+mu = expected_returns.mean_historical_return(prices)
+S = risk_models.sample_cov(prices)
+risk_aversion = 1.0
+transaction_cost = 0.01
+# assume we have started with equally weighted portfolio
+tickers = prices.columns
+n = len(tickers)
+initial_weights = np.array([1/n] * n)
+
+# Solution provided by PyPortfolio
+ef = EfficientFrontier(mu, S)
+ef.add_objective(objective_functions.transaction_cost, w_prev=initial_weights, k=transaction_cost)
+ef.max_quadratic_utility(risk_aversion=risk_aversion)
+weights_pyportf = np.array(list(ef.clean_weights().values()))
+print("Solution provided by PyPortfolio: ", weights_pyportf)
+
+# Solution provided by ReHLine
+L = LA.cholesky(S)
+A = np.r_[np.c_[np.ones(n), np.ones(n)*-1.0].T, np.eye(n)]
+b = np.r_[-1.0, 1.0, np.zeros(n)]
+X = LA.inv(L.T)
+A_tilde = A @ X
+mu_tilde = X.T @ mu
+tol = 1e-6
+
+markowitz = ReHLine(
+    C=risk_aversion, 
+    A=A_tilde, 
+    b=b,
+    U=transaction_cost*np.c_[np.ones(n), np.ones(n)*-1.0].T,
+    V=transaction_cost*np.c_[-initial_weights, initial_weights].T,
+    mu=mu_tilde,
+    tol=tol,
+)
+markowitz.fit(X=X)
+weights_rehline = X @ markowitz.coef_
+print("Solution provided by ReHLine: ", weights_rehline)
+print("L2 distance between solutions", LA.norm(weights_rehline - weights_pyportf))


### PR DESCRIPTION
- Added linear term to the objective function to handle optimizing problems of kind:
$$ \min_{\mathbf{w} \in R^d} -\mathbf{\mu}^T \mathbf{w} + \frac{\alpha}{2}\mathbf{w}^T \mathbf{S} \mathbf{w} + \sum_{i=1}^n \sum_{l=1}^L \text{ReLU}(u_{li} \mathbf{x_i}^T \mathbf{w} + v_{li}) + \sum_{i=1}^n \sum_{h=1}^H \text{ReHU}_{\tau_{hi}} (s_{hi} \mathbf{x_i}^T \mathbf{\mu} + t_{hi}) $$
- Added test script comparing a PyPortfolio's portfolio optimizer against the ReHLine optimizer