### PR TITLE
Update _base.py

### DIFF
--- a/rehline/_base.py
+++ b/rehline/_base.py
@@ -254,6 +254,7 @@ def _make_loss_rehline_param(loss, X, y):
     The function supports various loss functions, including:
         - 'hinge'
         - 'svm' or 'SVM'
+        - 'mae' or 'MAE' or 'mean absolute error'
         - 'check' or 'quantile' or 'quantile regression' or 'QR'
         - 'sSVM' or 'smooth SVM' or 'smooth hinge'
         - 'TV'
@@ -362,7 +363,7 @@ def _make_loss_rehline_param(loss, X, y):
     elif (loss['name'] == 'MAE') \
             or (loss['name'] == 'mae') \
             or (loss['name'] == 'mean absolute error'):
-        U = np.array([[1] * n, [-1] * n])
+        U = np.array([[1.0] * n, [-1.0] * n])
         V = np.array([-y , y])
 
     

--- a/rehline/_base.py
+++ b/rehline/_base.py
@@ -358,6 +358,14 @@ def _make_loss_rehline_param(loss, X, y):
         V[0] = -(y + loss['epsilon'])
         V[1] =  (y - loss['epsilon'])
 
+    
+    elif (loss['name'] == 'MAE') \
+            or (loss['name'] == 'mae') \
+            or (loss['name'] == 'mean absolute error'):
+        U = np.array([[1] * n, [-1] * n])
+        V = np.array([-y , y])
+
+    
     else:
         raise Exception("Sorry, ReHLine currently does not support this loss function, \
                         but you can manually set ReHLine params to solve the problem via `ReHLine` class.")


### PR DESCRIPTION
Made adjustments on `_make_loss_rehline_param()` function. Now this function supports giving rehline parameters for mean absolute error loss function.


$$\text{Let } S=\text{length of }y$$



$$U = \begin{pmatrix}
		1&1 &1 & \cdots &1 \\
		-1&-1 & -1 & \cdots &-1 \\
	\end{pmatrix} 
	\in R^{2\times S}$$


$$V = \begin{pmatrix}
		-y^T \\
		y^T \\
	\end{pmatrix} 
	\in R^{2\times S}$$
